### PR TITLE
Remove getattr for time steps

### DIFF
--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -484,6 +484,7 @@ class BmiTopoflowGlacier(BmiBase):
 
         # --- time-step index ---
         self._timestep = 0
+        self._t_index = 0
 
         # optionally skip expensive solar geometry if SW forcing exists
         self._skip_solar_geometry = True
@@ -561,9 +562,8 @@ class BmiTopoflowGlacier(BmiBase):
             self.update_combined_meltrate()
 
         # advance index AFTER computing step diagnostics
-        self._timestep = int(getattr(self, "_timestep", 0)) + 1
-        if hasattr(self, "_t_index"):
-            self._t_index = int(getattr(self, "_t_index", 0)) + 1
+        self._timestep += 1
+        self._t_index += 1
 
         # best-effort debug line for one-cell runs
         try:
@@ -808,8 +808,8 @@ class BmiTopoflowGlacier(BmiBase):
     def get_current_time(self) -> float:
         """Current model time in seconds since start, based on internal step index."""
         dt = float(self.get_time_step())
-        t = float(getattr(self, "_t_index", 0)) * dt
-        LOG.debug(f"get_current_time: t_index={getattr(self, '_t_index', 0)}, t={t}")
+        t = float(self._t_index) * dt
+        LOG.debug(f"get_current_time: t_index={self._t_index}, t={t}")
         return t
 
     def is_at_end_time(self) -> bool:


### PR DESCRIPTION
The logic of tracking time was not incrementing time. `get_current_time` relied on `self._t_index`, but because `self._t_index` was not set in `__init__` or `initialize`, it would never advance. In general, I would recommend against `getattr` for the BMI object since default values should be defined in `initialize` and the object lacking expected properties can properly trigger fail states.


## Changes

- `getattr` is no longer used to get `_timestep` and `_t_index` properties.
- `_t_index` is given a default value in `initialize`

## Testing

1. Local runs on AWS Workspace with additional logging for determining the CSV forcing data reader is advancing with the Topoflow Glacier BMI.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
