### PR TITLE
Exposing New Output Variables

### DIFF
--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -48,6 +48,10 @@ _output_vars = [
     ("precipitation_rate", "mm s-1"),
     # NEW: discharge expected by NGen (m3 s-1)
     ("channel_water_x-section__volume_flow_rate", "m3 s-1"),
+
+    ("atmosphere_water__snowfall_leq-volume_flux", "m s-1"),
+    ("snowpack__domain_time_integral_of_melt_volume_flux", "m3"),
+    ("land_surface__temperature", "degC"),
 ]
 
 # --------------   Complete Name Crosswalk   -----------------------------
@@ -73,14 +77,16 @@ INTERNAL_NAME_CROSSWALK = {
     "land_surface_wind__x_component_of_velocity": "U2D",
     "land_surface_wind__y_component_of_velocity": "V2D",
     "precipitation_rate": "P_rate",
+
+    # NEW output mappings
+    "atmosphere_water__snowfall_leq-volume_flux": "P_snow",
+    "snowpack__domain_time_integral_of_melt_volume_flux": "vol_SM",
+    "land_surface__temperature": "T_surf",
     # Unused variables:
     # "atmosphere_bottom_air__mass-per-volume_density": "rho_air",
     # "atmosphere_bottom_air__mass-specific_isobaric_heat_capacity": "Cp_air",
     # "land_surface_net-total-energy__energy_flux": "Q_sum",
-    # "land_surface__temperature": "T_surf",
-    # "atmosphere_water__snowfall_leq-volume_flux": "P_snow",
     # "water-liquid__mass-per-volume_density": "rho_H2O",
-    # "snowpack__domain_time_integral_of_melt_volume_flux": "vol_SM",
     # "snowpack__initial_domain_integral_of_liquid-equivalent_depth": "vol_swe_start",
     # "snowpack__domain_integral_of_liquid-equivalent_depth": "vol_swe",
     # "snowpack__energy-per-area_cold_content": "Eccs",
@@ -320,6 +326,21 @@ class BmiTopoflowGlacier(BmiBase):
         """Setter for the relative humidity state variable"""
         self._outputs.set_value("atmosphere_bottom_air_water-vapor__relative_saturation", value)
 
+    def _sync_internal_outputs(self) -> None:
+        """Copy internal model variables into the BMI output context."""
+        self._outputs.set_value(
+            "atmosphere_water__snowfall_leq-volume_flux",
+            np.asarray(self.P_snow, dtype="float64").reshape(-1),
+        )
+        self._outputs.set_value(
+            "snowpack__domain_time_integral_of_melt_volume_flux",
+            np.asarray(self.vol_SM, dtype="float64").reshape(-1),
+        )
+        self._outputs.set_value(
+            "land_surface__temperature",
+            np.asarray(self.T_surf, dtype="float64").reshape(-1),
+        )
+
     def initialize(self, config_file: str | Path) -> None:
         """Initialize the BMI model and pre-compute all bookkeeping needed by the adapter."""
         LOG.info("initialize")
@@ -502,6 +523,8 @@ class BmiTopoflowGlacier(BmiBase):
         # optionally skip expensive solar geometry if SW forcing exists
         self._skip_solar_geometry = True
 
+        self._sync_internal_outputs()
+
         LOG.info("initialize complete")
 
     def _init_three_day_snow_buffer(self) -> None:
@@ -582,6 +605,7 @@ class BmiTopoflowGlacier(BmiBase):
         self.update_wi_density_ratio()
         self.update_ice_depth()
         self.update_snowpack_cold_content()
+        self._sync_internal_outputs()
 
         # advance index AFTER computing step diagnostics
         self._timestep += 1

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -49,9 +49,9 @@ _output_vars = [
     # NEW: discharge expected by NGen (m3 s-1)
     ("channel_water_x-section__volume_flow_rate", "m3 s-1"),
 
-    ("atmosphere_water__snowfall_leq-volume_flux", "m s-1"),
-    ("snowpack__domain_time_integral_of_melt_volume_flux", "m3"),
-    ("land_surface__temperature", "degC"),
+    ("atmosphere_water__snowfall_leq-volume_flux", "mm s-1"),
+    ("snowpack__domain_time_integral_of_melt_volume_flux", "mm"),
+    ("land_surface__temperature", "K"),
 ]
 
 # --------------   Complete Name Crosswalk   -----------------------------
@@ -328,17 +328,21 @@ class BmiTopoflowGlacier(BmiBase):
 
     def _sync_internal_outputs(self) -> None:
         """Copy internal model variables into the BMI output context."""
+
+        # print("P_snow:", self.P_snow)
+        # print("vol_SM:", self.vol_SM)
+        # print("T_surf:", self.T_surf)
         self._outputs.set_value(
             "atmosphere_water__snowfall_leq-volume_flux",
-            np.asarray(self.P_snow, dtype="float64").reshape(-1),
+            np.asarray(self.P_snow * 1000.0, dtype="float64").reshape(-1),   # m/s -> mm/s
         )
         self._outputs.set_value(
             "snowpack__domain_time_integral_of_melt_volume_flux",
-            np.asarray(self.vol_SM, dtype="float64").reshape(-1),
+            np.asarray((self.vol_SM / self.da_m2) * 1000.0, dtype="float64").reshape(-1),  # m -> mm, if vol_SM is m3 over area
         )
         self._outputs.set_value(
             "land_surface__temperature",
-            np.asarray(self.T_surf, dtype="float64").reshape(-1),
+            np.asarray(self.T_surf + 273.15, dtype="float64").reshape(-1),   # degC -> K
         )
 
     def initialize(self, config_file: str | Path) -> None:
@@ -348,6 +352,8 @@ class BmiTopoflowGlacier(BmiBase):
         # --- load config (YAML -> TopoflowGlacierConfig) ---
         with open(config_file) as f:
             cfg_dict = yaml.safe_load(f)
+
+        print(f"bmi config file : {config_file}")
 
         for key in ("start_time", "end_time"):
             if key in cfg_dict and not isinstance(cfg_dict[key], str):
@@ -524,6 +530,8 @@ class BmiTopoflowGlacier(BmiBase):
         self._skip_solar_geometry = True
 
         self._sync_internal_outputs()
+        print(f"Output vars : {self.get_output_var_names()}")
+
 
         LOG.info("initialize complete")
 
@@ -2715,9 +2723,9 @@ class BmiTopoflowGlacier(BmiBase):
             "channel_water_x-section__volume_flow_rate": "m3 s-1",
 
             # New outputs
-            "atmosphere_water__snowfall_leq-volume_flux": "m s-1",
-            "snowpack__domain_time_integral_of_melt_volume_flux": "m3",
-            "land_surface__temperature": "degC",
+            "atmosphere_water__snowfall_leq-volume_flux": "mm s-1",
+            "snowpack__domain_time_integral_of_melt_volume_flux": "mm",
+            "land_surface__temperature": "K",
         }
         try:
             return units[name]

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -165,8 +165,8 @@ class BmiTopoflowGlacier(BmiBase):
         """Getter for the precipitation output variable in mm s-1"""
         return self._outputs.value("precipitation_rate")
 
-    @P.setter
-    def P(self, value: np.ndarray) -> None:
+    @P_rate.setter
+    def P_rate(self, value: np.ndarray) -> None:
         """Setter for the precipitation output variable in mm s-1"""
         self._outputs.set_value("precipitation_rate", value)
 
@@ -2686,6 +2686,7 @@ class BmiTopoflowGlacier(BmiBase):
 
         return self.start_datetime
 
+
     def get_var_units(self, name: str) -> str:
         units = {
             # Inputs (advertised)
@@ -2696,7 +2697,6 @@ class BmiTopoflowGlacier(BmiBase):
             "land_surface_air__pressure": "Pa",
             "atmosphere_air_water~vapor__relative_saturation": "1",
             "atmosphere_bottom_air_water-vapor__relative_saturation": "1",
-
             "wind_speed_UV": "m s-1",
             "land_surface_wind__speed": "m s-1",
             "land_surface_wind__x_component_of_velocity": "m s-1",
@@ -2713,6 +2713,11 @@ class BmiTopoflowGlacier(BmiBase):
             "glacier__liquid_equivalent_depth": "m",
             "precipitation_rate": "mm s-1",
             "channel_water_x-section__volume_flow_rate": "m3 s-1",
+
+            # New outputs
+            "atmosphere_water__snowfall_leq-volume_flux": "m s-1",
+            "snowpack__domain_time_integral_of_melt_volume_flux": "m3",
+            "land_surface__temperature": "degC",
         }
         try:
             return units[name]

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -329,16 +329,15 @@ class BmiTopoflowGlacier(BmiBase):
     def _sync_internal_outputs(self) -> None:
         """Copy internal model variables into the BMI output context."""
 
-        # print("P_snow:", self.P_snow)
-        # print("vol_SM:", self.vol_SM)
-        # print("T_surf:", self.T_surf)
         self._outputs.set_value(
             "atmosphere_water__snowfall_leq-volume_flux",
             np.asarray(self.P_snow * 1000.0, dtype="float64").reshape(-1),   # m/s -> mm/s
         )
+
+        snow_melt_mm = (self.vol_SM / self.da_m2) * 1000.0    # m -> mm, if vol_SM is m3 over area
         self._outputs.set_value(
             "snowpack__domain_time_integral_of_melt_volume_flux",
-            np.asarray((self.vol_SM / self.da_m2) * 1000.0, dtype="float64").reshape(-1),  # m -> mm, if vol_SM is m3 over area
+            np.asarray(snow_melt_mm, dtype="float64").reshape(-1),
         )
         self._outputs.set_value(
             "land_surface__temperature",
@@ -353,7 +352,7 @@ class BmiTopoflowGlacier(BmiBase):
         with open(config_file) as f:
             cfg_dict = yaml.safe_load(f)
 
-        print(f"bmi config file : {config_file}")
+        LOG.info(f"bmi config file : {config_file}")
 
         for key in ("start_time", "end_time"):
             if key in cfg_dict and not isinstance(cfg_dict[key], str):
@@ -530,7 +529,7 @@ class BmiTopoflowGlacier(BmiBase):
         self._skip_solar_geometry = True
 
         self._sync_internal_outputs()
-        print(f"Output vars : {self.get_output_var_names()}")
+        LOG.debug(f"Output vars : {self.get_output_var_names()}")
 
 
         LOG.info("initialize complete")


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-10155

Topoflow-glacier has been integrated into the output variable code. The following variables are not exposed as Topoflow-glacier outputs:

atmosphere_water__snowfall_leq-volume_flux (P_snow internal topoflow variable),
snowpack__domain_time_integral_of_melt_volume_flux (vol_SM internal), and
land_surface__temperature (T_surf internal)

This PR is to expose these variables through BMI so they can be activated by MSWM and written as outputs.

Documentation: https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/65765410/Topoflow-Glacier#TopoflowGlacier-ExposureofAdditionalTopoFlow-GlacierVariablesviaBMIforNWMIntegration