### PR TITLE
update unit of Topoflow-Glacier's depth value to kg/m2

### DIFF
--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -2384,28 +2384,28 @@ class BmiTopoflowGlacier(BmiBase):
     def get_value(self, name: str, dest) -> None:
         """BMI get_value: copy variable 'name' into provided 'dest' array."""
 
-        if name == "wind_speed_UV":
-            arr = np.array([self._wind_speed], dtype="float64")
-            if dest is None:
-                return arr.copy()
-            dest[: arr.size] = arr
-            return dest
-
-        # NWM SNEQV expects kg m-2, while Topoflow-Glacier stores h_swe as m.
         if name == "snowpack__liquid-equivalent_depth":
             src = np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
             np.copyto(dest, src)
             return dest
 
-        # Prefer outputs first, then inputs, so discharge/melt are readable
+        if name in ("wind_speed_UV", "land_surface_wind__speed"):
+            arr = np.array([self._wind_speed], dtype="float64")
+            np.copyto(dest, arr)
+            return dest
+
         if name in self._outputs:
             src = self._outputs.value(name)
         elif name in self._dynamic_inputs:
             src = self._dynamic_inputs.value(name)
+        elif name in self._calibs:
+            src = self._calibs.value(name)
         else:
             raise KeyError(f"Unknown BMI variable name: {name}")
-        np.copyto(dest, np.asarray(src, dtype="float64"))
 
+        np.copyto(dest, np.asarray(src, dtype="float64"))
+        return dest
+    
     def set_value(self, name: str, values) -> None:
         """BMI set_value: assign into BMI variable 'name' from 'values' array."""
         arr = np.asarray(values, dtype="float64").reshape(-1)
@@ -2612,11 +2612,11 @@ class BmiTopoflowGlacier(BmiBase):
         raise KeyError(f"Variable not found: {name}")
 
     def get_value_ptr(self, name: str) -> NDArray:
-        """Gets value in native form if exists in inputs or outputs"""
+        """Gets value in native form if exists in inputs or outputs."""
+
         if name in ("wind_speed_UV", "land_surface_wind__speed"):
             return np.array([self._wind_speed], dtype="float64")
 
-        # NWM SNEQV expects kg m-2, while Topoflow-Glacier stores h_swe as m.
         if name == "snowpack__liquid-equivalent_depth":
             self._sneqv_kg_m2 = (
                 np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -37,10 +37,10 @@ _calib_vars = [
 
 _output_vars = [
     ("snowpack__depth", "m"),
-    ("snowpack__liquid-equivalent_depth", "m"),
+    ("snowpack__liquid-equivalent_depth", "kg m-2"),
     ("snowpack__melt_volume_flux", "m s-1"),
     ("glacier_ice__thickness", "m"),
-    ("glacier__liquid_equivalent_depth", "kg m-2"),
+    ("glacier__liquid_equivalent_depth", "m"),
     ("glacier_ice__melt_volume_flux", "m s-1"),
     ("land_surface_water__runoff_volume_flux", "m s-1"),
     ("land_surface_water__runoff_depth", "m"),

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -38,7 +38,7 @@ _calib_vars = [
 _output_vars = [
     ("snowpack__depth", "m"),
     ("snowpack__liquid-equivalent_depth", "m"),
-    ("snowpack__liquid_equivalent_mass_per_area", "kg m-2"),
+    ("snowpack__liquid-equivalent_mass_per_area", "kg m-2"),
     ("snowpack__melt_volume_flux", "m s-1"),
     ("glacier_ice__thickness", "m"),
     ("glacier__liquid_equivalent_depth", "m"),
@@ -331,7 +331,7 @@ class BmiTopoflowGlacier(BmiBase):
         """Copy internal model variables into the BMI output context."""
 
         self._outputs.set_value(
-            "snowpack__liquid_equivalent_mass_per_area",
+            "snowpack__liquid-equivalent_mass_per_area",
             np.asarray(self.h_swe * self.rho_H2O, dtype="float64").reshape(-1),
         )
 
@@ -448,7 +448,7 @@ class BmiTopoflowGlacier(BmiBase):
         self._outputs.set_value("glacier_ice__thickness", np.array([self.cfg.h0_ice], dtype="float64"))
         self._outputs.set_value("snowpack__liquid-equivalent_depth", np.array([self.cfg.h0_swe], dtype="float64"))
         self._outputs.set_value(
-            "snowpack__liquid_equivalent_mass_per_area",
+            "snowpack__liquid-equivalent_mass_per_area",
             np.array([self.cfg.h0_swe * self.rho_H2O], dtype="float64"),
         )
         self._outputs.set_value("glacier__liquid_equivalent_depth", np.array([self.cfg.h0_iwe], dtype="float64"))
@@ -2729,7 +2729,7 @@ class BmiTopoflowGlacier(BmiBase):
             "snowpack__depth": "m",
             "glacier_ice__thickness": "m",
             "snowpack__liquid-equivalent_depth": "m",
-            "snowpack__liquid_equivalent_mass_per_area": "kg m-2",
+            "snowpack__liquid-equivalent_mass_per_area": "kg m-2",
             "glacier__liquid_equivalent_depth": "m",
             "precipitation_rate": "mm s-1",
             "channel_water_x-section__volume_flow_rate": "m3 s-1",

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -68,7 +68,6 @@ INTERNAL_NAME_CROSSWALK = {
     # Output variable mappings (only used ones)
     "snowpack__depth": "h_snow",
     "snowpack__liquid-equivalent_depth": "h_swe",
-    "snowpack__liquid_equivalent_mass_per_area": "sneqv",
     "snowpack__melt_volume_flux": "SM",
     "glacier_ice__thickness": "h_ice",
     "glacier__liquid_equivalent_depth": "h_iwe",
@@ -2410,7 +2409,7 @@ class BmiTopoflowGlacier(BmiBase):
         else:
             raise KeyError(f"Unknown BMI variable name: {name}")
         np.copyto(dest, np.asarray(src, dtype="float64"))
-    
+
     def set_value(self, name: str, values) -> None:
         """BMI set_value: assign into BMI variable 'name' from 'values' array."""
         arr = np.asarray(values, dtype="float64").reshape(-1)
@@ -2592,7 +2591,6 @@ class BmiTopoflowGlacier(BmiBase):
     def get_value_at_indices(self, name: str, dest: np.ndarray, inds: np.ndarray) -> np.ndarray:
         LOG.debug(f"get_value_at_indices: {name}")
         a_inds = np.asarray(inds, dtype=int)
-
         if hasattr(self, "_outputs") and name in self._outputs:
             return self._outputs.value_at_indices(name, dest, a_inds)
         if hasattr(self, "_inputs") and name in self._inputs:

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -2395,22 +2395,21 @@ class BmiTopoflowGlacier(BmiBase):
     def get_value(self, name: str, dest) -> None:
         """BMI get_value: copy variable 'name' into provided 'dest' array."""
 
-        if name in ("wind_speed_UV", "land_surface_wind__speed"):
+        if name == "wind_speed_UV":
             arr = np.array([self._wind_speed], dtype="float64")
-            np.copyto(dest, arr)
+            if dest is None:
+                return arr.copy()
+            dest[: arr.size] = arr
             return dest
 
+        # Prefer outputs first, then inputs, so discharge/melt are readable
         if name in self._outputs:
             src = self._outputs.value(name)
         elif name in self._dynamic_inputs:
             src = self._dynamic_inputs.value(name)
-        elif name in self._calibs:
-            src = self._calibs.value(name)
         else:
             raise KeyError(f"Unknown BMI variable name: {name}")
-
         np.copyto(dest, np.asarray(src, dtype="float64"))
-        return dest
     
     def set_value(self, name: str, values) -> None:
         """BMI set_value: assign into BMI variable 'name' from 'values' array."""

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -40,7 +40,7 @@ _output_vars = [
     ("snowpack__liquid-equivalent_depth", "m"),
     ("snowpack__melt_volume_flux", "m s-1"),
     ("glacier_ice__thickness", "m"),
-    ("glacier__liquid_equivalent_depth", "m"),
+    ("glacier__liquid_equivalent_depth", "kg m-2"),
     ("glacier_ice__melt_volume_flux", "m s-1"),
     ("land_surface_water__runoff_volume_flux", "m s-1"),
     ("land_surface_water__runoff_depth", "m"),
@@ -2391,6 +2391,12 @@ class BmiTopoflowGlacier(BmiBase):
             dest[: arr.size] = arr
             return dest
 
+        # NWM SNEQV expects kg m-2, while Topoflow-Glacier stores h_swe as m.
+        if name == "snowpack__liquid-equivalent_depth":
+            src = np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
+            np.copyto(dest, src)
+            return dest
+
         # Prefer outputs first, then inputs, so discharge/melt are readable
         if name in self._outputs:
             src = self._outputs.value(name)
@@ -2581,6 +2587,12 @@ class BmiTopoflowGlacier(BmiBase):
     def get_value_at_indices(self, name: str, dest: np.ndarray, inds: np.ndarray) -> np.ndarray:
         LOG.debug(f"get_value_at_indices: {name}")
         a_inds = np.asarray(inds, dtype=int)
+
+        if name == "snowpack__liquid-equivalent_depth":
+            src = np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
+            dest[: a_inds.size] = src[a_inds]
+            return dest
+
         if hasattr(self, "_outputs") and name in self._outputs:
             return self._outputs.value_at_indices(name, dest, a_inds)
         if hasattr(self, "_inputs") and name in self._inputs:
@@ -2603,6 +2615,14 @@ class BmiTopoflowGlacier(BmiBase):
         """Gets value in native form if exists in inputs or outputs"""
         if name in ("wind_speed_UV", "land_surface_wind__speed"):
             return np.array([self._wind_speed], dtype="float64")
+
+        # NWM SNEQV expects kg m-2, while Topoflow-Glacier stores h_swe as m.
+        if name == "snowpack__liquid-equivalent_depth":
+            self._sneqv_kg_m2 = (
+                np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
+            )
+            return self._sneqv_kg_m2
+
         return first_containing(name, self._outputs, self._dynamic_inputs, self._calibs).value(name)
 
     def get_var_itemsize(self, name: str) -> int:
@@ -2716,7 +2736,7 @@ class BmiTopoflowGlacier(BmiBase):
             "land_surface_water__runoff_depth": "m",
             "snowpack__depth": "m",
             "glacier_ice__thickness": "m",
-            "snowpack__liquid-equivalent_depth": "m",
+            "snowpack__liquid-equivalent_depth": "kg m-2",
             "glacier__liquid_equivalent_depth": "m",
             "precipitation_rate": "mm s-1",
             "channel_water_x-section__volume_flow_rate": "m3 s-1",

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -37,7 +37,8 @@ _calib_vars = [
 
 _output_vars = [
     ("snowpack__depth", "m"),
-    ("snowpack__liquid-equivalent_depth", "kg m-2"),
+    ("snowpack__liquid-equivalent_depth", "m"),
+    ("snowpack__liquid_equivalent_mass_per_area", "kg m-2"),
     ("snowpack__melt_volume_flux", "m s-1"),
     ("glacier_ice__thickness", "m"),
     ("glacier__liquid_equivalent_depth", "m"),
@@ -67,6 +68,7 @@ INTERNAL_NAME_CROSSWALK = {
     # Output variable mappings (only used ones)
     "snowpack__depth": "h_snow",
     "snowpack__liquid-equivalent_depth": "h_swe",
+    "snowpack__liquid_equivalent_mass_per_area": "sneqv",
     "snowpack__melt_volume_flux": "SM",
     "glacier_ice__thickness": "h_ice",
     "glacier__liquid_equivalent_depth": "h_iwe",
@@ -330,6 +332,11 @@ class BmiTopoflowGlacier(BmiBase):
         """Copy internal model variables into the BMI output context."""
 
         self._outputs.set_value(
+            "snowpack__liquid_equivalent_mass_per_area",
+            np.asarray(self.h_swe * self.rho_H2O, dtype="float64").reshape(-1),
+        )
+
+        self._outputs.set_value(
             "atmosphere_water__snowfall_leq-volume_flux",
             np.asarray(self.P_snow * 1000.0, dtype="float64").reshape(-1),   # m/s -> mm/s
         )
@@ -441,6 +448,10 @@ class BmiTopoflowGlacier(BmiBase):
         self._outputs.set_value("snowpack__depth", np.array([self.cfg.h0_snow], dtype="float64"))
         self._outputs.set_value("glacier_ice__thickness", np.array([self.cfg.h0_ice], dtype="float64"))
         self._outputs.set_value("snowpack__liquid-equivalent_depth", np.array([self.cfg.h0_swe], dtype="float64"))
+        self._outputs.set_value(
+            "snowpack__liquid_equivalent_mass_per_area",
+            np.array([self.cfg.h0_swe * self.rho_H2O], dtype="float64"),
+        )
         self._outputs.set_value("glacier__liquid_equivalent_depth", np.array([self.cfg.h0_iwe], dtype="float64"))
         self._outputs.set_value("channel_water_x-section__volume_flow_rate", np.array([0.0], dtype="float64"))
         self._outputs.set_value("precipitation_rate", np.array([0.0], dtype="float64"))
@@ -2384,11 +2395,6 @@ class BmiTopoflowGlacier(BmiBase):
     def get_value(self, name: str, dest) -> None:
         """BMI get_value: copy variable 'name' into provided 'dest' array."""
 
-        if name == "snowpack__liquid-equivalent_depth":
-            src = np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
-            np.copyto(dest, src)
-            return dest
-
         if name in ("wind_speed_UV", "land_surface_wind__speed"):
             arr = np.array([self._wind_speed], dtype="float64")
             np.copyto(dest, arr)
@@ -2588,11 +2594,6 @@ class BmiTopoflowGlacier(BmiBase):
         LOG.debug(f"get_value_at_indices: {name}")
         a_inds = np.asarray(inds, dtype=int)
 
-        if name == "snowpack__liquid-equivalent_depth":
-            src = np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
-            dest[: a_inds.size] = src[a_inds]
-            return dest
-
         if hasattr(self, "_outputs") and name in self._outputs:
             return self._outputs.value_at_indices(name, dest, a_inds)
         if hasattr(self, "_inputs") and name in self._inputs:
@@ -2616,12 +2617,6 @@ class BmiTopoflowGlacier(BmiBase):
 
         if name in ("wind_speed_UV", "land_surface_wind__speed"):
             return np.array([self._wind_speed], dtype="float64")
-
-        if name == "snowpack__liquid-equivalent_depth":
-            self._sneqv_kg_m2 = (
-                np.asarray(self._outputs.value(name), dtype="float64") * self.rho_H2O
-            )
-            return self._sneqv_kg_m2
 
         return first_containing(name, self._outputs, self._dynamic_inputs, self._calibs).value(name)
 
@@ -2736,7 +2731,8 @@ class BmiTopoflowGlacier(BmiBase):
             "land_surface_water__runoff_depth": "m",
             "snowpack__depth": "m",
             "glacier_ice__thickness": "m",
-            "snowpack__liquid-equivalent_depth": "kg m-2",
+            "snowpack__liquid-equivalent_depth": "m",
+            "snowpack__liquid_equivalent_mass_per_area": "kg m-2",
             "glacier__liquid_equivalent_depth": "m",
             "precipitation_rate": "mm s-1",
             "channel_water_x-section__volume_flow_rate": "m3 s-1",


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-10218

**Issue**

snowpack__liquid-equivalent_depth was previously exposed in kg m⁻², while its name and internal representation correspond to depth (m)
This created a semantic mismatch and violated BMI naming conventions: depth variable ≠ mass units

**Fix**
1. Restore original depth variable
snowpack__liquid-equivalent_depth → m
No conversion is applied. This reflects the true physical meaning (water-equivalent depth).

2. Introduce new NWM-facing variable
snowpack__liquid_equivalent_mass_per_area → kg m⁻²
Computed in BMI as: mass_per_area = depth_m × ρ_water

3. Implementation changes
Updated _output_vars to include both variables
Added new crosswalk entry
Added derived variable in _sync_internal_outputs()
Removed SWE conversion from get_value*() methods
Initialized new variable in initialize()

**Why**

Preserves semantic correctness:

depth → m
mass → kg m⁻²
Avoids confusing downstream users and reviewers


**Final Mapping**
Variable	Meaning	Units
snowpack__liquid-equivalent_depth	SWE depth	m
snowpack__liquid_equivalent_mass_per_area	SWE mass (NWM SNEQV)	kg m⁻