### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -9,14 +9,52 @@ import sys
 import gc
 from numpy.typing import NDArray
 
-import ewts
-LOG = ewts.get_logger(ewts.TOPOFLOW_GLACIER_ID)
-
 from topoflow_glacier.bmi.bmi_base import BmiBase
 from topoflow_glacier.bmi.config import TopoflowGlacierConfig
 from topoflow_glacier.physics import solar_funcs as solar
 from topoflow_glacier.physics.context import Context, build_context
 
+import logging
+LOG = logging.getLogger("TFGLACR") # IMPORTANT! Use exact string from ewts.modules.TOPOFLOW_GLACIER_ID
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+)
+
+import os
+
+# NOTE: Helper function to ensure reading env vars
+# When run within ngen some env vars are set from C++ after the 
+# Python interpreter has started.
+# In embedded Python, os.environ may not reflect those changes.
+# getenv_any() falls back to libc getenv() and syncs os.environ.
+def getenv_any(key: str, default: str = "") -> str:
+    """
+    Get an environment variable reliably even when it is set from C/C++
+    after the Python interpreter has started (embedded Python).
+    Prefers os.environ/os.getenv, falls back to libc getenv.
+    """
+    # First try Python's mapping
+    v = os.environ.get(key)
+    if v is not None:
+        return v
+
+    # Fallback: direct libc getenv (sees process env even if Python mapping is stale)
+    try:
+        import ctypes, ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"))
+        libc.getenv.restype = ctypes.c_char_p
+        b = libc.getenv(key.encode("utf-8"))
+        if not b:
+            return default
+        s = b.decode("utf-8")
+
+        # Sync back into os.environ so future lookups work normally
+        os.environ[key] = s
+        return s
+    except Exception:
+        return default
+    
 __all__ = ["BmiTopoflowGlacier"]
 
 _dynamic_input_vars = [
@@ -141,12 +179,25 @@ class BmiTopoflowGlacier(BmiBase):
     """BMI composition wrapper for TopoflowGlacier"""
 
     def __init__(self) -> None:
+        # Determine if running within ngen using EWTS. This must be done  
+        # here when the model actually runs vs when it is imported 
+        # into the ngen Python interpreter to ensure the env vars are set.
+        print(f"__init__ Reading EWTS_USE_NGEN_BRIDGE")
+        val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            print(f"__init__ Found EWTS_USE_NGEN_BRIDGE")
+            try:
+                from ewts.logger import configure_existing_logger
+            except ImportError:
+                LOG.warning("EWTS_USE_NGEN_BRIDGE is set, but EWTS package is not installed. Falling back to default logging.")
+                return
+
+            # Reconfigure logger for EWTS logging
+            configure_existing_logger(LOG)
+
         self._dynamic_inputs = build_context(_dynamic_input_vars)
         self._calibs = build_context(_calib_vars)
         self._outputs = build_context(_output_vars)
-
-        # This is required prior to the first log message is issued by t-route.
-        LOG.bind()
 
     @property
     def P(self) -> np.ndarray:

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -16,44 +16,16 @@ from topoflow_glacier.physics.context import Context, build_context
 
 import logging
 LOG = logging.getLogger("TFGLACR") # IMPORTANT! Use exact string from ewts.modules.TOPOFLOW_GLACIER_ID
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
-)
-
-import os
-
-# NOTE: Helper function to ensure reading env vars
-# When run within ngen some env vars are set from C++ after the 
-# Python interpreter has started.
-# In embedded Python, os.environ may not reflect those changes.
-# getenv_any() falls back to libc getenv() and syncs os.environ.
-def getenv_any(key: str, default: str = "") -> str:
-    """
-    Get an environment variable reliably even when it is set from C/C++
-    after the Python interpreter has started (embedded Python).
-    Prefers os.environ/os.getenv, falls back to libc getenv.
-    """
-    # First try Python's mapping
-    v = os.environ.get(key)
-    if v is not None:
-        return v
-
-    # Fallback: direct libc getenv (sees process env even if Python mapping is stale)
-    try:
-        import ctypes, ctypes.util
-        libc = ctypes.CDLL(ctypes.util.find_library("c"))
-        libc.getenv.restype = ctypes.c_char_p
-        b = libc.getenv(key.encode("utf-8"))
-        if not b:
-            return default
-        s = b.decode("utf-8")
-
-        # Sync back into os.environ so future lookups work normally
-        os.environ[key] = s
-        return s
-    except Exception:
-        return default
+try:
+    from ewts.helper import getenv_any
+    from ewts.logger import configure_existing_logger
+    TFGLACR_USE_EWTS = True
+except ImportError:
+    TFGLACR_USE_EWTS = False
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+    )
     
 __all__ = ["BmiTopoflowGlacier"]
 
@@ -179,21 +151,15 @@ class BmiTopoflowGlacier(BmiBase):
     """BMI composition wrapper for TopoflowGlacier"""
 
     def __init__(self) -> None:
-        # Determine if running within ngen using EWTS. This must be done  
-        # here when the model actually runs vs when it is imported 
-        # into the ngen Python interpreter to ensure the env vars are set.
-        print(f"__init__ Reading EWTS_USE_NGEN_BRIDGE")
-        val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
-        if val in {"1", "true", "yes", "on"}:
-            print(f"__init__ Found EWTS_USE_NGEN_BRIDGE")
-            try:
-                from ewts.logger import configure_existing_logger
-            except ImportError:
-                LOG.warning("EWTS_USE_NGEN_BRIDGE is set, but EWTS package is not installed. Falling back to default logging.")
-                return
-
-            # Reconfigure logger for EWTS logging
-            configure_existing_logger(LOG)
+        if TFGLACR_USE_EWTS:
+            # Determine if running within ngen using EWTS. This must be done  
+            # here when the model actually runs vs when it is imported 
+            # into the ngen Python interpreter to ensure the env vars are set.
+            val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+            if val in {"1", "true", "yes", "on"}:
+                configure_existing_logger(LOG) # Reconfigure logger for EWTS logging
+            else:
+                LOG.warning("EWTS installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
 
         self._dynamic_inputs = build_context(_dynamic_input_vars)
         self._calibs = build_context(_calib_vars)

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -22,10 +22,6 @@ try:
     TFGLACR_USE_EWTS = True
 except ImportError:
     TFGLACR_USE_EWTS = False
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
-    )
     
 __all__ = ["BmiTopoflowGlacier"]
 
@@ -146,7 +142,20 @@ def load_static_attributes(cfg: dict[str, Any], state: Context):
         value = cfg[internal_name]
         state.set_value(external_name, bmi_array([value]))
 
+def _configure_stdout_logging():
+    LOG.setLevel(logging.INFO)
 
+    if not LOG.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - "
+            "[%(filename)s:%(lineno)s - %(funcName)s]: %(message)s"
+        ))
+        LOG.addHandler(handler)
+
+    LOG.propagate = False
+    
 class BmiTopoflowGlacier(BmiBase):
     """BMI composition wrapper for TopoflowGlacier"""
 
@@ -157,9 +166,12 @@ class BmiTopoflowGlacier(BmiBase):
             # into the ngen Python interpreter to ensure the env vars are set.
             val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
             if val in {"1", "true", "yes", "on"}:
-                configure_existing_logger(LOG) # Reconfigure logger for EWTS logging
+                configure_existing_logger(LOG)
             else:
-                LOG.warning("EWTS installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+                _configure_stdout_logging()
+                LOG.warning("EWTS importable but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+        else:
+            _configure_stdout_logging()
 
         self._dynamic_inputs = build_context(_dynamic_input_vars)
         self._calibs = build_context(_calib_vars)

--- a/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
+++ b/src/topoflow_glacier/bmi/bmi_topoflow_glacier.py
@@ -14,6 +14,7 @@ from topoflow_glacier.bmi.config import TopoflowGlacierConfig
 from topoflow_glacier.physics import solar_funcs as solar
 from topoflow_glacier.physics.context import Context, build_context
 
+from datetime import datetime, timezone
 import logging
 LOG = logging.getLogger("TFGLACR") # IMPORTANT! Use exact string from ewts.modules.TOPOFLOW_GLACIER_ID
 try:
@@ -142,20 +143,42 @@ def load_static_attributes(cfg: dict[str, Any], state: Context):
         value = cfg[internal_name]
         state.set_value(external_name, bmi_array([value]))
 
+class StdoutStyleFormatter(logging.Formatter):
+
+    INFO_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s %(message)s"
+    )
+
+    DETAILED_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s "
+        "%(message)s "
+        "[%(filename)s.%(funcName)s(L%(lineno)s)]"
+    )
+
+    def format(self, record):
+        if record.levelno == logging.INFO:
+            self._style._fmt = self.INFO_FORMAT
+        else:
+            self._style._fmt = self.DETAILED_FORMAT
+
+        return super().format(record)
+    
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
 def _configure_stdout_logging():
     LOG.setLevel(logging.INFO)
 
     if not LOG.handlers:
         handler = logging.StreamHandler()
         handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - "
-            "[%(filename)s:%(lineno)s - %(funcName)s]: %(message)s"
-        ))
+        handler.setFormatter(StdoutStyleFormatter())
         LOG.addHandler(handler)
 
     LOG.propagate = False
-    
+
 class BmiTopoflowGlacier(BmiBase):
     """BMI composition wrapper for TopoflowGlacier"""
 
@@ -169,7 +192,7 @@ class BmiTopoflowGlacier(BmiBase):
                 configure_existing_logger(LOG)
             else:
                 _configure_stdout_logging()
-                LOG.warning("EWTS importable but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+                LOG.warning("ewts package installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
         else:
             _configure_stdout_logging()
 

--- a/src/topoflow_glacier/physics/context.py
+++ b/src/topoflow_glacier/physics/context.py
@@ -5,10 +5,8 @@ from collections.abc import Iterable, Iterator
 import numpy as np
 from pydantic import BaseModel, ConfigDict
 
-
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.TOPOFLOW_GLACIER_ID)
+LOG = logging.getLogger("TFGLACR")
 
 def _ensure(condition: bool, message: str) -> None:
     """

--- a/src/topoflow_glacier/physics/solar_funcs.py
+++ b/src/topoflow_glacier/physics/solar_funcs.py
@@ -121,8 +121,7 @@ import pandas as pd
 from timezonefinder import TimezoneFinder
 
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.TOPOFLOW_GLACIER_ID)
+LOG = logging.getLogger("TFGLACR")
 
 tf = TimezoneFinder()
 


### PR DESCRIPTION
Update to reconfigure a native Python logger to an EWTS logger when the ewts package is installed and the `EWTS_USE_NGEN_BRIDGE` environment variable set by ngen indicates to use ewts for logging.

## Additions

- Call to `configure_existing_logger` when ewts is present and `EWTS_USE_NGEN_BRIDGE` is true
- Logs to stdout follow same format pattern currently used by ewts, <timestamp> <module> <log level> <message>. If log level above INFO, the filename, method name and line number also appended to the log message.

## Removals

- Importing ewts in all modules that log

## Changes

- Change setting `LOG` from the ewts named logger to an Python logger named `TFLGACR` 

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`